### PR TITLE
Fix export data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ tests/*.csv
 tests.m
 tests
 *.asv
+
+.DS_Store

--- a/data/data_export.m
+++ b/data/data_export.m
@@ -147,17 +147,17 @@ headers = [{'channel'} {'label'} {'amplitude (uV)'} {'latency (ms)'}];
 switch filt_id
     case 1
         if  exist([pathname filename], 'file')
-            [~, ~, previous_data] = xlsread([pathname filename]);
-            xlswrite([pathname filename], [previous_data; export_data])
+            previous_data = readcell([pathname filename]);
+            writecell([previous_data; export_data], [pathname filename])
         else
-            xlswrite([pathname filename], [headers; export_data])
+            writecell([headers; export_data], [pathname filename])
         end
         
         if  exist([pathname_av filename_av], 'file')
-            [~, ~, previous_data_av] = xlsread([pathname_av filename_av]);
-            xlswrite([pathname_av filename_av], [previous_data_av; export_data_av])
+            previous_data_av = readcell([pathname_av filename_av]);
+            writecell([previous_data_av; export_data_av], [pathname_av filename_av])
         else
-            xlswrite([pathname_av filename_av], [headers; export_data_av])
+            writecell([headers; export_data_av], [pathname_av filename_av])
         end
         
     case 2


### PR DESCRIPTION
Replace xls read and write with cell read and write when exporting MEP_Analysis processed data. The use of xls functions was raising an error in newer Matlab versions.